### PR TITLE
Compatibility with Rails Engine

### DIFF
--- a/lib/active_hash_relation/aggregation.rb
+++ b/lib/active_hash_relation/aggregation.rb
@@ -12,6 +12,9 @@ module ActiveHashRelation
 
       unless @model
         @model = model_class_name(@resource)
+        if @model.nil? || engine_name == @model.to_s
+          @model = model_class_name(@resource, true)
+        end
       end
     end
 

--- a/lib/active_hash_relation/association_filters.rb
+++ b/lib/active_hash_relation/association_filters.rb
@@ -2,6 +2,9 @@ module ActiveHashRelation::AssociationFilters
   def filter_associations(resource, params, model = nil)
     unless model
       model = model_class_name(resource)
+      if model.nil? || engine_name == model.to_s
+        model = model_class_name(resource, true)
+      end
     end
 
     model.reflect_on_all_associations.map(&:name).each do |association|

--- a/lib/active_hash_relation/filter_applier.rb
+++ b/lib/active_hash_relation/filter_applier.rb
@@ -21,6 +21,9 @@ module ActiveHashRelation
     def apply_filters
       unless @model
         @model = model_class_name(@resource)
+        if @model.nil? || engine_name == @model.to_s
+          @model = model_class_name(@resource, true)
+        end
       end
       table_name = @model.table_name
       @model.columns.each do |c|

--- a/lib/active_hash_relation/helpers.rb
+++ b/lib/active_hash_relation/helpers.rb
@@ -1,7 +1,16 @@
 module ActiveHashRelation
   module Helpers
-    def model_class_name(resource)
-      resource.class.to_s.split('::').first.constantize
+    def model_class_name(resource, _engine = false)
+      _class = resource.class.to_s.split('::')
+      if _engine === true
+        "#{_class[0]}::#{_class[1]}".constantize
+      else
+        _class.first.constantize
+      end
+    end
+
+    def engine_name
+      Rails::Engine.subclasses[0].to_s.split('::').first
     end
   end
 end

--- a/lib/active_hash_relation/scope_filters.rb
+++ b/lib/active_hash_relation/scope_filters.rb
@@ -2,6 +2,9 @@ module ActiveHashRelation::ScopeFilters
   def filter_scopes(resource, params, model = nil)
     unless model
       model = model_class_name(resource)
+      if model.nil? || engine_name == model.to_s
+        model = model_class_name(resource, true)
+      end
     end
 
     model.scope_names.each do |scope|


### PR DESCRIPTION
I was trying to use active_hash_relation gem in a Rails Engine, but I was getting the following error:

```
NoMethodError: undefined method `table_name' for Blog:Module
Did you mean?  table_name_prefix
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/active_hash_relation-1.1.0/lib/active_hash_relation/filter_applier.rb:25:in `apply_filters'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/active_hash_relation-1.1.0/lib/active_hash_relation.rb:35:in `apply_filters'
    /home/mdamaceno/Desenvolvimento/ruby/manager/blog/app/controllers/blog/api/v1/categories_controller.rb:7:in `index'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/abstract_controller/base.rb:198:in `process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/action_controller/metal/rendering.rb:10:in `process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/callbacks.rb:117:in `call'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/callbacks.rb:505:in `call'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/callbacks.rb:92:in `__run_callbacks__'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/abstract_controller/callbacks.rb:19:in `process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/action_controller/metal/rescue.rb:29:in `process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/notifications.rb:164:in `block in instrument'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activesupport-4.2.5.1/lib/active_support/notifications.rb:164:in `instrument'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/activerecord-4.2.5.1/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/abstract_controller/base.rb:137:in `process'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionview-4.2.5.1/lib/action_view/rendering.rb:30:in `process'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/action_controller/test_case.rb:639:in `process'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/action_controller/test_case.rb:67:in `process'
    /home/mdamaceno/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5.1/lib/action_controller/test_case.rb:514:in `get'
    /home/mdamaceno/Desenvolvimento/ruby/manager/blog/test/support/json_parsed.rb:6:in `json_parsed'
    /home/mdamaceno/Desenvolvimento/ruby/manager/blog/test/controllers/blog/api/v1/categories_controller_test.rb:12:in `block in <class:CategoriesControllerTest>'
```

I resolved this with some modifications in the code. I hope my modifications are helpful and they help to improve the gem. Sorry for my English.