### PR TITLE
Add support for enum columns when the value is a string

### DIFF
--- a/lib/active_hash_relation/filter_applier.rb
+++ b/lib/active_hash_relation/filter_applier.rb
@@ -33,6 +33,9 @@ module ActiveHashRelation
 
         case c.type
         when :integer
+          if @model.defined_enums[c.name] && @model.defined_enums[c.name][@params[c.name]]
+            @params[c.name] = @model.defined_enums[c.name][@params[c.name]]
+          end
           @resource = filter_integer(@resource, c.name, table_name, @params[c.name])
         when :float
           @resource = filter_float(@resource, c.name, table_name, @params[c.name])

--- a/spec/tests/numbers_spec.rb
+++ b/spec/tests/numbers_spec.rb
@@ -137,6 +137,17 @@ describe ActiveHashRelation do
 
         expect(strip(query)).to eq expected_query.to_s
       end
+
+      it 'rails string enum' do
+        hash = {status: 'published'}
+
+        query = HelperClass.new.apply_filters(Micropost.all, hash).to_sql
+        expected_query = q(
+          "SELECT microposts.* FROM microposts WHERE (microposts.status = #{Micropost.statuses[:published]})"
+        )
+
+        expect(strip(query)).to eq expected_query.to_s
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

The Rails standard way to access and serialize enum columns is using its string representation, not the integer one.
So, this commits add compatibility to filter enum columns through its string value representation, without any conversion need by the user.

Thanks